### PR TITLE
Revert "Try another workaround for https://github.com/bazel-contrib/r…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,17 +19,6 @@ bazel_dep(name = "gazelle", version = "0.41.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "go.mod")
-
-# Work around https://github.com/bazel-contrib/rules_go/issues/4154 and
-# https://github.com/bazel-contrib/bazel-gazelle/issues/1393.  See
-# https://github.com/bazel-contrib/rules_go/issues/4154#issuecomment-2433739889.
-go_deps.gazelle_override(
-    directives = [
-        "gazelle:build_tags purego",
-        "gazelle:exclude **/*_amd64*",
-    ],
-    path = "github.com/cloudflare/circl",
-)
 use_repo(
     go_deps,
     "com_github_bazelbuild_buildtools",


### PR DESCRIPTION
…ules_go/issues/4154 and https://github.com/bazel-contrib/bazel-gazelle/issues/1393"

The override in MODULE.bazel makes the module unusable. See whether the flags in the GitHub workflow config are sufficient.

This reverts commit 478001e893b333c5683177ec0035ebf51878acd3.