### PR TITLE
Revert "Try another workaround for https://github.com/bazel-contrib/rules_go/issues/4154 and https://github.com/bazel-contrib/bazel-gazelle/issues/1393"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,10 +51,5 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Run tests
         shell: bash
-        # Work around https://github.com/bazel-contrib/rules_go/issues/4154 and
-        # https://github.com/bazel-contrib/bazel-gazelle/issues/1393.  See
-        # https://github.com/bazel-contrib/rules_go/issues/4154#issuecomment-2433739889.
-        run: >-
-          make check
-          BAZEL=bazelisk
-          BAZELFLAGS='--@rules_go//go/config:pure --define=gotags=purego'
+        run: |
+          make check BAZEL=bazelisk


### PR DESCRIPTION
This reverts commit 478001e893b333c5683177ec0035ebf51878acd3.

https://github.com/bazel-contrib/rules_go/issues/4154 is fixed upstream.